### PR TITLE
Fix: The first collabocate instance created by each individual User must be global

### DIFF
--- a/@server/@api-manager_collabocate/instance.service.ts
+++ b/@server/@api-manager_collabocate/instance.service.ts
@@ -15,17 +15,14 @@ export const createCollabocateInstanceService = async (user_id: string, requestB
     notFoundErr('No record found for provided ID');
   }
   
-  if (Object.keys(requestBody).includes("global") && requestBody.global === true) {
-    const query = await CollabocateInstance.findOne({global: true}).exec();
-    if(query){
-      badRequestErr('A global setting already exists, Only One Global Setting can exist');
+  const instances = await CollabocateInstance.find().exec(); 
+  if (instances.length === 0) { // if it is the first instance being created, the instance must be global
+    if (!Object.keys(requestBody).includes("global") || !requestBody.global === true || requestBody.instance_name) {
+      badRequestErr('First instance must have global: true and no <instance_name> property'); 
     }
-    if (requestBody.instance_name) {
-      badRequestErr('global setting does not require <instance_name> property');
-    }
-  } else {
-    if (!requestBody.instance_name) {
-      badRequestErr('<instance_name> property is required for non global settings');
+  } else { // if it is not the first instance being created, the instance must not be global
+    if (requestBody.global === true || !requestBody.instance_name) {
+      badRequestErr('A global instance already exists or no <instance_name> property for non global instance'); 
     }
   }
 

--- a/@server/@api-manager_collabocate/instance.service.ts
+++ b/@server/@api-manager_collabocate/instance.service.ts
@@ -15,7 +15,7 @@ export const createCollabocateInstanceService = async (user_id: string, requestB
     notFoundErr('No record found for provided ID');
   }
   
-  const instances = await CollabocateInstance.find().exec(); 
+  const instances = await CollabocateInstance.find({ user: user }).exec(); 
   if (instances.length === 0) { // if it is the first instance being created, the instance must be global
     if (!Object.keys(requestBody).includes("global") || !requestBody.global === true || requestBody.instance_name) {
       badRequestErr('First instance must have global: true and no <instance_name> property'); 


### PR DESCRIPTION
#### This pull request makes the following changes

* Fixes collabo-community/issue-tickets-ready-for-fixing#90

#

#### General checklist

- [x] My pull request adheres to the [Collabo Community pull request guidelines](https://docs.collabocommunity.com/pull-request-guidelines).
- [x] I have read and understood the **Pull request guideline extension** section found at the bottom of this pull request description/body.
- [x] I have replaced the dummy text under the subheading **Testing checklist** below with the testing checklist from the issue ticket I'm working on.

#

#### Testing checklist

- [x] API-server checks if the first instance created by a user has global property set to true.
- [x] I certify that I ran my checklist

#

#### Pull request guideline extension

> [!NOTE]  
> Do not remove this note or section. This talks about extra things to take note of, in addition to the directions given in the Collabo Community pull request guidelines.

We appreciate the time taken to help tackle issue tickets within the Collabo Community. Please go ahead to submit your pull request even if it is not yet completed, and push to the pull request actively. This will allow us to know that you have not abandoned the issue ticket. However, you should only alert reviewers about your pull request as explained below, to avoid flooding their GitHub notifications unnecessarily.

"Ready for review" implies that things are working as expected, according to how it is specified in the issue ticket you are working on. Ensure that you test the code that you are working on, that it works as expected. Don't just request for review when your pull request is not yet done and working.

The only time you should be making people review something incomplete is: if you want to show them what's not working, so that they can send help or guidance. If this is the case, be explicit about this in our Discord community or in the comment of your pull request (after you have submitted the pull request).
